### PR TITLE
Reintroduce custom force size. Use default values from preferences.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -485,9 +485,10 @@
 	<string name="pref_xperiapro_title">Sony Ericsson Xperia (mini) pro fix</string>
 	<string name="pref_xperiapro_summary">Hardware keyboard fixes</string>
 	
-	<!--  Force size-->
-	<string name="pref_force_size">Force Size</string>
-	<string name="force_size_width">Width</string>
-	<string name="force_size_height">Height</string>
-		
+	<!--  Force screen size -->
+	<string name="pref_default_fsize_category">Default values for force size</string>
+	<string name="pref_default_fsize_width">Default width for force size</string>
+	<string name="pref_default_fsize_width_summary">Default screen width in rows for force resize</string>
+	<string name="pref_default_fsize_height">Default height for force size</string>
+	<string name="pref_default_fsize_height_summary">Default screen height in columns for force resize</string>		
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -184,14 +184,22 @@
 		/>
 		
 	<PreferenceCategory
-		android:title="@string/pref_force_size">		
+		android:title="@string/pref_default_fsize_category">
+
 		<EditTextPreference
-	   		android:key="force_width"
-	   		android:title="@string/force_size_width"
-	   		/>
+			android:key="default_fsize_width"
+			android:title="@string/pref_default_fsize_width"
+			android:summary="@string/pref_default_fsize_width_summary"
+			android:defaultValue="80"
+			android:numeric="integer"
+			/>
+
 		<EditTextPreference
-	   		android:key="force_height"
-	   		android:title="@string/force_size_height"
-	   		/>
-   	</PreferenceCategory>
+			android:key="default_fsize_height"
+			android:title="@string/pref_default_fsize_height"
+			android:summary="@string/pref_default_fsize_height_summary"
+			android:defaultValue="25"
+			android:numeric="integer"
+			/>
+	</PreferenceCategory>
 </PreferenceScreen>

--- a/src/org/woltage/irssiconnectbot/ConsoleActivity.java
+++ b/src/org/woltage/irssiconnectbot/ConsoleActivity.java
@@ -588,18 +588,41 @@ public class ConsoleActivity extends Activity {
 		resize.setEnabled(sessionOpen);
 		resize.setOnMenuItemClickListener(new OnMenuItemClickListener() {
 			public boolean onMenuItemClick(MenuItem item) {
-				int width = new Integer(prefs.getString("force_width", "0"));
-				int height = new Integer(prefs.getString("force_height", "0"));
+				final TerminalView terminalView = (TerminalView) findCurrentView(R.id.console_flip);
 
-				if(width > 0 && height > 0) {
-					terminalView.forceSize(width, height);
-					terminalView.forceSize(width, height);
-				} else {
-					new AlertDialog.Builder(ConsoleActivity.this)
-						.setMessage("Goto settings and add width/height values.")
-						.setTitle("No configuration")
-						.show();
-				}
+				final View resizeView = inflater.inflate(R.layout.dia_resize, null, false);
+				((EditText) resizeView.findViewById(R.id.width))
+					.setText(prefs.getString("default_fsize_width", "80"));
+				((EditText) resizeView.findViewById(R.id.height))
+					.setText(prefs.getString("default_fsize_height", "25"));
+
+				new AlertDialog.Builder(ConsoleActivity.this)
+					.setView(resizeView)
+					.setPositiveButton(R.string.button_resize, new DialogInterface.OnClickListener() {
+						public void onClick(DialogInterface dialog, int which) {
+							int width, height;
+							try {
+								width = Integer.parseInt(((EditText) resizeView
+										.findViewById(R.id.width))
+										.getText().toString());
+								height = Integer.parseInt(((EditText) resizeView
+										.findViewById(R.id.height))
+										.getText().toString());
+							} catch (NumberFormatException nfe) {
+								// TODO change this to a real dialog where we can
+								// make the input boxes turn red to indicate an error.
+								return;
+							}
+							if (width > 0 && height > 0)
+								terminalView.forceSize(width, height);
+							else {
+								new AlertDialog.Builder(ConsoleActivity.this)
+									.setMessage("Width and height must be higher than zero.")
+									.setTitle("Error")
+									.show();
+							}
+						}
+					}).setNegativeButton(android.R.string.cancel, null).create().show();
 
 				return true;
 			}

--- a/src/org/woltage/irssiconnectbot/ConsoleActivity.java
+++ b/src/org/woltage/irssiconnectbot/ConsoleActivity.java
@@ -29,6 +29,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;

--- a/src/org/woltage/irssiconnectbot/ConsoleActivity.java
+++ b/src/org/woltage/irssiconnectbot/ConsoleActivity.java
@@ -247,6 +247,10 @@ public class ConsoleActivity extends Activity {
 	protected void hideAllPrompts() {
 		stringPromptGroup.setVisibility(View.GONE);
 		booleanPromptGroup.setVisibility(View.GONE);
+		// adjust screen size if it was changed during prompt input
+		View view = findCurrentView(R.id.console_flip);
+		if(!(view instanceof TerminalView)) return;
+		((TerminalView)view).bridge.parentChanged((TerminalView)view);
 	}
 
 	// more like configureLaxMode -- enable network IO on UI thread

--- a/src/org/woltage/irssiconnectbot/ConsoleActivity.java
+++ b/src/org/woltage/irssiconnectbot/ConsoleActivity.java
@@ -616,6 +616,7 @@ public class ConsoleActivity extends Activity {
 							}
 							if (width > 0 && height > 0)
 								terminalView.forceSize(width, height);
+								terminalView.bridge.parentChanged(terminalView);
 							else {
 								new AlertDialog.Builder(ConsoleActivity.this)
 									.setMessage("Width and height must be higher than zero.")


### PR DESCRIPTION
This way users can specify a custom force size, but the fields are pre-filled with values from preferences.
In preferences, check the values being integers.
