### PR TITLE
Remove ActionBar from ConsoleActivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -49,7 +49,7 @@
                  android:description="@string/service_desc"/>
 
         <activity android:name=".ConsoleActivity" android:configChanges="keyboardHidden|orientation"
-                  android:theme="@style/NoTitle" android:windowSoftInputMode="stateAlwaysVisible|adjustResize"
+                  android:theme="@android:style/Theme.Holo.NoActionBar" android:windowSoftInputMode="stateAlwaysVisible|adjustResize"
                   android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
Now ConsoleActivity takes up as much space as it did previously.  The ActionBar did not appear to have anything useful on it, and I noticed a few complaints on the market comments.  I compiled it with a target sdk of 8, and did not encounter any errors with ConsoleActivity's new theme attribute.  I am running ICS, though, so I don't know how this will work on devices running GingerBread or below.
