### PR TITLE
Removing ActionBar is now a user preference.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -49,7 +49,7 @@
                  android:description="@string/service_desc"/>
 
         <activity android:name=".ConsoleActivity" android:configChanges="keyboardHidden|orientation"
-                  android:theme="@android:style/Theme.Holo.NoActionBar" android:windowSoftInputMode="stateAlwaysVisible|adjustResize"
+            android:theme="@style/NoTitle" android:windowSoftInputMode="stateAlwaysVisible|adjustResize"
                   android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -198,6 +198,11 @@
 	<!-- Summary for the haptic feedback (bumpy arrow) preference -->
 	<string name="pref_bumpyarrows_summary">"Vibrate when sending arrow keys from trackball; useful for laggy connections"</string>
 
+  <!-- Name for the action bar preference -->
+  <string name="pref_actionbar_title">"Action Bar"</string>
+  <!-- Sumary for the action bar preference -->
+  <string name="pref_actionbar_summary">"Display Action Bar in a session.  Note: Honeycomb and Ice Cream Sandwich users may need the Action Bar to access the menu."</string>
+
 	<!-- Category title for the Terminal Bell preferences -->
 	<string name="pref_bell_category">"Terminal bell"</string>
 

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -66,7 +66,8 @@
 	</PreferenceCategory>
 
 	<PreferenceCategory
-		android:title="@string/pref_ui_category">
+		android:title="@string/pref_ui_category"
+    android:key="pref_ui_category">
 
 		<ListPreference
 			android:key="rotation"
@@ -122,6 +123,14 @@
 			android:summary="@string/pref_bumpyarrows_summary"
 			android:defaultValue="true"
 			/>
+
+    <CheckBoxPreference
+      android:key="actionbarsetting"
+      android:title="@string/pref_actionbar_title"
+      android:summary="@string/pref_actionbar_summary"
+      android:defaultValue="true"
+      />
+    
 	</PreferenceCategory>
 
 	<PreferenceCategory

--- a/src/org/woltage/irssiconnectbot/ConsoleActivity.java
+++ b/src/org/woltage/irssiconnectbot/ConsoleActivity.java
@@ -27,6 +27,7 @@ import org.woltage.irssiconnectbot.util.PreferenceConstants;
 import com.bugsense.trace.BugSenseHandler;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.ActionBar;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -274,6 +275,21 @@ public class ConsoleActivity extends Activity {
 
 		clipboard = (ClipboardManager)getSystemService(CLIPBOARD_SERVICE);
 		prefs = PreferenceManager.getDefaultSharedPreferences(this);
+
+		// hide action bar if requested by user
+		try
+		{
+			ActionBar actionBar = getActionBar();
+			if (!prefs.getBoolean(PreferenceConstants.ACTIONBAR, true))
+			{
+				actionBar.hide();
+			}
+		}
+		catch (NoSuchMethodError error)
+		{
+			Log.w(TAG, "Android sdk version pre 11.	Not touching ActionBar.");
+		}
+
 
 		// hide status bar if requested by user
 		if (prefs.getBoolean(PreferenceConstants.FULLSCREEN, false)) {

--- a/src/org/woltage/irssiconnectbot/SettingsActivity.java
+++ b/src/org/woltage/irssiconnectbot/SettingsActivity.java
@@ -20,8 +20,11 @@ package org.woltage.irssiconnectbot;
 import org.woltage.irssiconnectbot.util.PreferenceConstants;
 
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -51,8 +54,19 @@ public class SettingsActivity extends PreferenceActivity {
 			editor.commit();
 
 			addPreferencesFromResource(R.xml.preferences);
+
+			// Check version of Android running on device and display Action Bar preference accordingly
+			// This can be extended to hide other HoneyComb or greater settings
+
 		}
 
+		int sdkVersion = Integer.parseInt(Build.VERSION.SDK);
+		if (sdkVersion < Build.VERSION_CODES.HONEYCOMB)
+		{
+			PreferenceCategory uiCategory = (PreferenceCategory) findPreference("pref_ui_category");
+			CheckBoxPreference actionBarCheckBox = (CheckBoxPreference) findPreference("actionbarsetting");
+			uiCategory.removePreference(actionBarCheckBox);
+		}
 		// TODO: add parse checking here to make sure we have integer value for scrollback
 
 	}

--- a/src/org/woltage/irssiconnectbot/util/PreferenceConstants.java
+++ b/src/org/woltage/irssiconnectbot/util/PreferenceConstants.java
@@ -68,6 +68,8 @@ public class PreferenceConstants {
 
 	public static final String BUMPY_ARROWS = "bumpyarrows";
 
+	public static final String ACTIONBAR = "actionbarsetting";
+
 	public static final String EULA = "eula";
 
 	public static final String SORT_BY_COLOR = "sortByColor";


### PR DESCRIPTION
I noticed in issue 30 that the Honeycomb user needed the ActionBar to access the Activity settings.  My previous pull request also showed the TitleBar for pre-Honeycomb users, whereas this was not the case before my commit was merged.  This commit fixes both of those issues.

---

Commit Message:

The user, if they are running SDK >= 11 will have an option in
SettingsActivity to enable or disable the ActionBar for ConsoleActivity.
The option exists because some Honeycomb and Ice Cream Sandwich users
might need the ActionBar to access the Activity menu, while others may
prefer to not see the ActionBar at all since it takes up a fair amount
of space.

Users SDK <= 10 will not be given this option and for them
ConsoleActivity will not have a TitleBar, just as it was in previous
versions.
