### PR TITLE
Update build.xml to work with sdk-r16

### DIFF
--- a/ant.properties
+++ b/ant.properties
@@ -1,21 +1,20 @@
 # This file is used to override default values used by the Ant build system.
 #
-# This file must be checked in Version Control Systems, as it is
+# This file must be checked into Version Control Systems, as it is
 # integral to the build system of your project.
 
-# The name of your application package as defined in the manifest.
-# Used by the 'uninstall' rule.
-application-package=org.woltage.irssiconnectbot
 # This file is only used by the Ant script.
 
-# The name of the source folder.
-source.dir=src
-
-# The name of the output folder.
-out.dir=bin
+# You can use this to override default values such as
+#  'source.dir' for the location of your java source folder and
+#  'out.dir' for the location of your output folder.
 
 # You can also use it define how the release builds are signed by declaring
 # the following properties:
 #  'key.store' for the location of your keystore and
 #  'key.alias' for the name of the key to use.
 # The password will be asked during the build when you use the 'release' target.
+
+application-package=org.woltage.irssiconnectbot
+source.dir=src
+out.dir=bin

--- a/build.xml
+++ b/build.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="ConnectBot" default="help">
 
-<!-- The local.properties file is created and updated by the 'android'
-     tool.
-     It contains the path to the SDK. It should *NOT* be checked into
-     Version Control Systems. -->
+    <!-- The local.properties file is created and updated by the 'android' tool.
+         It contains the path to the SDK. It should *NOT* be checked into
+         Version Control Systems. -->
     <property file="local.properties" />
 
-    <!-- The build.properties file can be created by you and is never touched
-         by the 'android' tool. This is the place to change some of the
-         default property values used by the Ant rules.
+    <!-- The ant.properties file can be created by you. It is only edited by the
+         'android' tool to add properties to it.
+         This is the place to change some Ant specific build properties.
          Here are some properties you may want to change/update:
 
          source.dir
              The name of the source directory. Default is 'src'.
          out.dir
              The name of the output directory. Default is 'bin'.
+
+         For other overridable properties, look at the beginning of the rules
+         files in the SDK, at tools/ant/build.xml
 
          Properties related to the SDK location or the project target should
          be updated using the 'android' tool with the 'update' action.
@@ -24,13 +26,24 @@
          application and should be checked into Version Control Systems.
 
          -->
-    <property file="build.properties" />
+    <property file="ant.properties" />
 
-    <!-- The default.properties file is created and updated by the 'android'
+    <!-- The project.properties file is created and updated by the 'android'
          tool, as well as ADT.
+
+         This contains project specific properties such as project target, and library
+         dependencies. Lower level build properties are stored in ant.properties
+         (or in .classpath for Eclipse projects).
+
          This file is an integral part of the build system for your
          application and should be checked into Version Control Systems. -->
-    <property file="default.properties" />
+    <loadproperties srcFile="project.properties" />
+
+    <!-- quick check on sdk.dir -->
+    <fail
+            message="sdk.dir is missing. Make sure to generate local.properties using 'android update project' or to inject it through an env var"
+            unless="sdk.dir"
+    />
 
     <!-- Custom Android task to deal with the project target, and import the
          proper rules.
@@ -41,7 +54,42 @@
         <pathelement path="${sdk.dir}/tools/lib/androidprefs.jar" />
     </path>
 
-<!-- Begin custom ConnectBot stuff -->
+    <!--
+        Import per project custom build rules if present at the root of the project.
+        This is the place to put custom intermediary targets such as:
+            -pre-build
+            -pre-compile
+            -post-compile (This is typically used for code obfuscation.
+                           Compiled code location: ${out.classes.absolute.dir}
+                           If this is not done in place, override ${out.dex.input.absolute.dir})
+            -post-package
+            -post-build
+            -pre-clean
+    -->
+    <import file="custom_rules.xml" optional="true" />
+
+    <!-- Import the actual build file.
+
+         To customize existing targets, there are two options:
+         - Customize only one target:
+             - copy/paste the target into this file, *before* the
+               <import> task.
+             - customize it to your needs.
+         - Customize the whole content of build.xml
+             - copy/paste the content of the rules files (minus the top node)
+               into this file, replacing the <import> task.
+             - customize to your needs.
+
+         ***********************
+         ****** IMPORTANT ******
+         ***********************
+         In all cases you must update the value of version-tag below to read 'custom' instead of an integer,
+         in order to avoid having your file be overridden by tools such as "android update project"
+    -->
+    <!-- version-tag: custom -->
+    <import file="${sdk.dir}/tools/ant/build.xml" />
+
+    <!-- Begin custom ConnectBot stuff -->
 
     <property name="proguard.out.dir" value="${out.dir}/proguard.out"/>
     <property name="out.dex.input.absolute.dir" value="${proguard.out.dir}"/>
@@ -93,9 +141,9 @@
         <taskdef resource="proguard/ant/task.properties"
                 classpath="tools/proguard.jar" />
         <proguard configuration="proguard.flags" printusage="${out.dir}/proguard.usage">
-            <injar path="${out.classes.dir}"/>
+            <injar path="${out.classes.absolute.dir}"/>
             <outjar path="${proguard.out.dir}"/>
-            <libraryjar path="${android.jar}"/>
+            <libraryjar path="${android.jar}:libs/bugsense-trace-1-1.jar"/>
         </proguard>
     </target>
 
@@ -151,11 +199,18 @@
         description="Clean up the result of the build process">
         <delete dir="${out.absolute.dir}"/>
         <delete dir="${gen.absolute.dir}"/>
-        <exec executable="ant" failonerror="true">
-            <arg value="-f" />
-            <arg value="tests/build.xml" />
-            <arg value="clean"/>
-        </exec>
+        <!-- if we know about a tested project or libraries, we clean them too. This
+             will only work if the target 'all' was called first -->
+        <if condition="${project.is.test}">
+            <then>
+                <property name="tested.project.absolute.dir" location="${tested.project.dir}" />
+                <subant failonerror="true">
+                    <fileset dir="${tested.project.absolute.dir}" includes="build.xml" />
+                    <target name="all" />
+                    <target name="clean" />
+                </subant>
+            </then>
+        </if>
     </target>
 
     <target name="tests" depends="install">
@@ -206,9 +261,4 @@
 
 <!-- End custom ConnectBot stuff -->
 
-    <taskdef name="setup"
-        classname="com.android.ant.SetupTask"
-        classpathref="android.antlibs" />
-
-    <setup />
 </project>


### PR DESCRIPTION
Using the old build.xml only gave the following message:

"Error. You are using an obsolete build.xml. You need to delete it and regenerate it using android update project"

I updated the build.xml, so it will now build with the SDK version.
