### PR TITLE
Notification sounds and vibration

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="lib" path="libs/bugsense-trace-1-1.jar"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -503,5 +503,7 @@
 	<string name="pref_default_fsize_width">Default width for force size</string>
 	<string name="pref_default_fsize_width_summary">Default screen width in rows for force resize</string>
 	<string name="pref_default_fsize_height">Default height for force size</string>
-	<string name="pref_default_fsize_height_summary">Default screen height in columns for force resize</string>		
+	<string name="pref_default_fsize_height_summary">Default screen height in columns for force resize</string>
+	<string name="pref_bell_notification_sound_title">Use notification sound</string>
+	<string name="pref_bell_notification_sound_summary">Use system-wide settings for sound and vibration</string>		
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -159,6 +159,7 @@
 			android:summary="@string/pref_bell_notification_summary"
 			android:defaultValue="false"
 			/>
+		<CheckBoxPreference android:key="bellNotificationSound" android:summary="@string/pref_bell_notification_sound_summary" android:title="@string/pref_bell_notification_sound_title"/>
 
 	</PreferenceCategory>
 	<ListPreference

--- a/src/org/woltage/irssiconnectbot/service/ConnectionNotifier.java
+++ b/src/org/woltage/irssiconnectbot/service/ConnectionNotifier.java
@@ -63,7 +63,7 @@ public abstract class ConnectionNotifier {
 		return notification;
 	}
 
-	protected Notification newActivityNotification(Context context, HostBean host) {
+	protected Notification newActivityNotification(Context context, HostBean host, boolean sound) {
 		Notification notification = newNotification(context);
 
 		Resources res = context.getResources();
@@ -82,7 +82,7 @@ public abstract class ConnectionNotifier {
 
 		notification.flags = Notification.FLAG_AUTO_CANCEL;
 
-		notification.flags |= Notification.DEFAULT_LIGHTS;
+		notification.defaults |= Notification.DEFAULT_LIGHTS;
 		if (HostDatabase.COLOR_RED.equals(host.getColor()))
 			notification.ledARGB = Color.RED;
 		else if (HostDatabase.COLOR_GREEN.equals(host.getColor()))
@@ -94,6 +94,8 @@ public abstract class ConnectionNotifier {
 		notification.ledOnMS = 300;
 		notification.ledOffMS = 1000;
 		notification.flags |= Notification.FLAG_SHOW_LIGHTS;
+		if (sound)
+			notification.defaults |= Notification.DEFAULT_SOUND | Notification.DEFAULT_VIBRATE;
 
 		return notification;
 	}
@@ -119,8 +121,8 @@ public abstract class ConnectionNotifier {
 		return notification;
 	}
 
-	public void showActivityNotification(Service context, HostBean host) {
-		getNotificationManager(context).notify(ACTIVITY_NOTIFICATION, newActivityNotification(context, host));
+	public void showActivityNotification(Service context, HostBean host, boolean sound) {
+		getNotificationManager(context).notify(ACTIVITY_NOTIFICATION, newActivityNotification(context, host, sound));
 	}
 
 	public void hideActivityNotification(Service context) {

--- a/src/org/woltage/irssiconnectbot/service/TerminalManager.java
+++ b/src/org/woltage/irssiconnectbot/service/TerminalManager.java
@@ -26,9 +26,9 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.Map.Entry;
 
 import org.woltage.irssiconnectbot.R;
 import org.woltage.irssiconnectbot.bean.HostBean;
@@ -598,7 +598,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		if (!prefs.getBoolean(PreferenceConstants.BELL_NOTIFICATION, false))
 			return;
 
-		ConnectionNotifier.getInstance().showActivityNotification(this, host);
+		ConnectionNotifier.getInstance().showActivityNotification(this, host, prefs.getBoolean(PreferenceConstants.BELL_NOTIFICATION_SOUND, false));
 	}
 
 	/* (non-Javadoc)

--- a/src/org/woltage/irssiconnectbot/util/PreferenceConstants.java
+++ b/src/org/woltage/irssiconnectbot/util/PreferenceConstants.java
@@ -78,6 +78,7 @@ public class PreferenceConstants {
 	public static final String BELL_VOLUME = "bellVolume";
 	public static final String BELL_VIBRATE = "bellVibrate";
 	public static final String BELL_NOTIFICATION = "bellNotification";
+	public static final String BELL_NOTIFICATION_SOUND = "bellNotificationSound";
 	public static final float DEFAULT_BELL_VOLUME = 0.25f;
 
 	public static final String CONNECTION_PERSIST = "connPersist";


### PR DESCRIPTION
I've added an option that allows for system default sound and vibration with the notification. 

I've also fixed a bug where it was ORing DEFAULT_LIGHTS into flags instead of defaults. DEFAULT_LIGHTS == FLAG_INSISTENT, which made my audio notifications rather annoying. 
