### PR TITLE
Small update

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="lib" path="libs/bugsense-trace-1-1.jar"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/src/org/woltage/irssiconnectbot/service/TerminalManager.java
+++ b/src/org/woltage/irssiconnectbot/service/TerminalManager.java
@@ -29,6 +29,7 @@ import org.woltage.irssiconnectbot.bean.HostBean;
 import org.woltage.irssiconnectbot.bean.PubkeyBean;
 import org.woltage.irssiconnectbot.transport.TransportFactory;
 import org.woltage.irssiconnectbot.util.HostDatabase;
+import org.woltage.irssiconnectbot.util.KeyUtils;
 import org.woltage.irssiconnectbot.util.PreferenceConstants;
 import org.woltage.irssiconnectbot.util.PubkeyDatabase;
 import org.woltage.irssiconnectbot.util.PubkeyUtils;
@@ -134,11 +135,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 		for (PubkeyBean pubkey : pubkeys) {
 			try {
-				PrivateKey privKey = PubkeyUtils.decodePrivate(pubkey.getPrivateKey(), pubkey.getType());
-				PublicKey pubKey = PubkeyUtils.decodePublic(pubkey.getPublicKey(), pubkey.getType());
-				Object trileadKey = PubkeyUtils.convertToTrilead(privKey, pubKey);
-
-				addKey(pubkey, trileadKey);
+				addKey(pubkey, KeyUtils.DecodeKey(pubkey, null));
 			} catch (Exception e) {
 				Log.d(TAG, String.format("Problem adding key '%s' to in-memory cache", pubkey.getNickname()), e);
 			}

--- a/src/org/woltage/irssiconnectbot/util/KeyUtils.java
+++ b/src/org/woltage/irssiconnectbot/util/KeyUtils.java
@@ -1,0 +1,37 @@
+/**
+ *
+ */
+package org.woltage.irssiconnectbot.util;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+import org.woltage.irssiconnectbot.bean.PubkeyBean;
+
+import com.trilead.ssh2.crypto.PEMDecoder;
+
+/**
+ * @author seaders
+ *
+ */
+public class KeyUtils {
+
+	public static Object DecodeKey(PubkeyBean pubkey, String password) throws IOException, Exception {
+		Object trileadKey = null;
+		if(PubkeyDatabase.KEY_TYPE_IMPORTED.equals(pubkey.getType())) {
+			// load specific key using pem format
+			trileadKey = PEMDecoder.decode(new String(pubkey.getPrivateKey()).toCharArray(), password);
+
+		} else {
+			// load using internal generated format
+			PrivateKey privKey = PubkeyUtils.decodePrivate(pubkey.getPrivateKey(), pubkey.getType(), password);
+			PublicKey pubKey = PubkeyUtils.decodePublic(pubkey.getPublicKey(), pubkey.getType());
+
+			// convert key to trilead format
+			trileadKey = PubkeyUtils.convertToTrilead(privKey, pubKey);
+		}
+
+		return trileadKey;
+	}
+}


### PR DESCRIPTION
PEMs marked to load at startup weren't due to inconsistent handling of different keys.  New class, with a static method "KeyUtils" created to ensure PEMs and other go through a consistent loading mechanism.

Bugsense removed from the Eclipse classpath file.
