### PR TITLE
Optionally use volume keys for ctrl and tab

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -499,6 +499,10 @@
 	<!--  Sony Ericsson Xperia pro and Xperia mini pro -->
 	<string name="pref_xperiapro_title">Sony Ericsson Xperia (mini) pro fix</string>
 	<string name="pref_xperiapro_summary">Hardware keyboard fixes</string>
+
+	<!-- Should volume keys resize or act as tab and ctrl? -->
+	<string name="pref_volumeresize_title">Use volume keys to resize terminal</string>
+	<string name="pref_volumeresize_summary">If true, volume keys will resize the terminal. Otherwise, volume up will act as tab and down as ctrl</string>
 	
 	<!--  Force screen size -->
 	<string name="pref_default_fsize_category">Default values for force size</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -194,11 +194,19 @@
     		android:summary="@string/pref_searchbutton_summary"
     		android:defaultValue="urlscan"
     		/>
+
 	<CheckBoxPreference
 		android:key="xperiaProFix"
 		android:title="@string/pref_xperiapro_title"
 		android:summary="@string/pref_xperiapro_summary"
 		android:defaultValue="false"
+		/>
+
+	<CheckBoxPreference
+		android:key="volumeKeysResize"
+		android:title="@string/pref_volumeresize_title"
+		android:summary="@string/pref_volumeresize_summary"
+		android:defaultValue="true"
 		/>
 		
 	<PreferenceCategory

--- a/src/org/woltage/irssiconnectbot/service/TerminalKeyListener.java
+++ b/src/org/woltage/irssiconnectbot/service/TerminalKeyListener.java
@@ -183,12 +183,14 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 			}
 
 			// check for terminal resizing keys
-			if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
-				bridge.increaseFontSize();
-				return true;
-			} else if(keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
-				bridge.decreaseFontSize();
-				return true;
+			if (prefs.getBoolean("volumeKeysResize", true)) {
+				if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+					bridge.increaseFontSize();
+					return true;
+				} else if(keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+					bridge.decreaseFontSize();
+					return true;
+				}
 			}
 
 			// skip keys if we aren't connected yet or have been disconnected
@@ -466,6 +468,7 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 
                     return true;
 			case KeyEvent.KEYCODE_TAB:
+			case KeyEvent.KEYCODE_VOLUME_UP:
 				bridge.transport.write(0x09);
 				return true;
 			case KEYCODE_PAGE_DOWN:
@@ -573,6 +576,7 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 				return true;
 			case KeyEvent.KEYCODE_DPAD_CENTER:
 			case KeyEvent.KEYCODE_SWITCH_CHARSET:
+			case KeyEvent.KEYCODE_VOLUME_DOWN:
 				if (keyCode == KeyEvent.KEYCODE_SWITCH_CHARSET && !prefs.getBoolean("xperiaProFix", false))
 					return true;
 				if ((metaState & META_CTRL_ON) != 0) {


### PR DESCRIPTION
On devices without a trackball or hard keyboard, pressing ctrl, alt,
and tab can be quite tedious. This allows the user to use the volume
keys for this purpose instead of zoom control.
