### PR TITLE
Make the action bar transient instead of completely hidden.

### DIFF
--- a/src/org/woltage/irssiconnectbot/ConsoleActivity.java
+++ b/src/org/woltage/irssiconnectbot/ConsoleActivity.java
@@ -399,6 +399,9 @@ public class ConsoleActivity extends Activity {
 
 				inputManager.showSoftInput(flip, InputMethodManager.SHOW_FORCED);
 				keyboardGroup.setVisibility(View.GONE);
+				if (!prefs.getBoolean(PreferenceConstants.ACTIONBAR, true)) {
+				    getActionBar().hide();
+				}
 			}
 		});
 
@@ -413,6 +416,9 @@ public class ConsoleActivity extends Activity {
 				TerminalKeyListener handler = terminal.bridge.getKeyHandler();
 				handler.showCharPickerDialog(terminal);
 				keyboardGroup.setVisibility(View.GONE);
+				if (!prefs.getBoolean(PreferenceConstants.ACTIONBAR, true)) {
+				    getActionBar().hide();
+				}
 			}
 		});
 
@@ -435,6 +441,9 @@ public class ConsoleActivity extends Activity {
 				promptThread.start();
 
 				keyboardGroup.setVisibility(View.GONE);
+				if (!prefs.getBoolean(PreferenceConstants.ACTIONBAR, true)) {
+				    getActionBar().hide();
+				}
 			}
 		});
 
@@ -450,6 +459,9 @@ public class ConsoleActivity extends Activity {
 				terminal.bridge.tryKeyVibrate();
 
 				keyboardGroup.setVisibility(View.GONE);
+				if (!prefs.getBoolean(PreferenceConstants.ACTIONBAR, true)) {
+				    getActionBar().hide();
+				}
 			}
 		});
 
@@ -464,6 +476,9 @@ public class ConsoleActivity extends Activity {
 				handler.sendEscape();
 				terminal.bridge.tryKeyVibrate();
 				keyboardGroup.setVisibility(View.GONE);
+				if (!prefs.getBoolean(PreferenceConstants.ACTIONBAR, true)) {
+				    getActionBar().hide();
+				}
 			}
 		});
 

--- a/src/org/woltage/irssiconnectbot/ConsoleActivity.java
+++ b/src/org/woltage/irssiconnectbot/ConsoleActivity.java
@@ -58,6 +58,7 @@ import android.view.MenuItem.OnMenuItemClickListener;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnKeyListener;
+import android.view.Window;
 import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
@@ -281,10 +282,14 @@ public class ConsoleActivity extends Activity {
 
         hardKeyboard = hardKeyboard && !Build.MODEL.startsWith("Transformer");
 
+		prefs = PreferenceManager.getDefaultSharedPreferences(this);
+		if (!prefs.getBoolean(PreferenceConstants.ACTIONBAR, true)) {
+			requestWindowFeature(Window.FEATURE_ACTION_BAR_OVERLAY);
+		}
+
 		this.setContentView(R.layout.act_console);
 
 		clipboard = (ClipboardManager)getSystemService(CLIPBOARD_SERVICE);
-		prefs = PreferenceManager.getDefaultSharedPreferences(this);
 
 		// hide action bar if requested by user
 		try {
@@ -467,8 +472,8 @@ public class ConsoleActivity extends Activity {
 				new ICBSimpleOnGestureListener(this));
 
 		flip.setLongClickable(true);
-		flip.setOnTouchListener(new ICBOnTouchListener(this, keyboardGroup, detect));
-
+		ActionBar actionBar = prefs.getBoolean(PreferenceConstants.ACTIONBAR, true) ? null : getActionBar();
+		flip.setOnTouchListener(new ICBOnTouchListener(this, keyboardGroup, actionBar, detect));
 	}
 
 	/**

--- a/src/org/woltage/irssiconnectbot/ICBOnTouchListener.java
+++ b/src/org/woltage/irssiconnectbot/ICBOnTouchListener.java
@@ -30,16 +30,28 @@ class ICBOnTouchListener implements View.OnTouchListener {
 
 	private final RelativeLayout keyboardGroup;
 	private final GestureDetector detect;
+	private final Handler handler = new Handler();
+	private final Runnable hider;
 
 	private float lastX, lastY;
 	private int lastTouchRow, lastTouchCol;
-	private Handler handler = new Handler();
 	private ConsoleActivity consoleActivity;
+
+	private class Hider implements Runnable {
+		public void run() {
+			if (keyboardGroup.getVisibility() == View.GONE)
+				return;
+
+			keyboardGroup.startAnimation(consoleActivity.keyboard_fade_out);
+			keyboardGroup.setVisibility(View.GONE);
+		}
+	}
 
 	public ICBOnTouchListener (ConsoleActivity consoleActivity, RelativeLayout keyboardGroup, GestureDetector detect) {
 		this.consoleActivity = consoleActivity;
 		this.keyboardGroup = keyboardGroup;
 		this.detect = detect;
+		this.hider = new Hider();
 	}
 
 	public boolean onTouch(View v, MotionEvent event) {
@@ -119,15 +131,7 @@ class ICBOnTouchListener implements View.OnTouchListener {
 			keyboardGroup.startAnimation(consoleActivity.keyboard_fade_in);
 			keyboardGroup.setVisibility(View.VISIBLE);
 
-			handler.postDelayed(new Runnable() {
-				public void run() {
-					if (keyboardGroup.getVisibility() == View.GONE)
-						return;
-
-					keyboardGroup.startAnimation(consoleActivity.keyboard_fade_out);
-					keyboardGroup.setVisibility(View.GONE);
-				}
-			}, ConsoleActivity.KEYBOARD_DISPLAY_TIME);
+			handler.postDelayed(this.hider, ConsoleActivity.KEYBOARD_DISPLAY_TIME);
 		}
 
 		// pass any touch events back to detector

--- a/src/org/woltage/irssiconnectbot/ICBOnTouchListener.java
+++ b/src/org/woltage/irssiconnectbot/ICBOnTouchListener.java
@@ -17,6 +17,7 @@
 
 package org.woltage.irssiconnectbot;
 
+import android.app.ActionBar;
 import android.content.res.Configuration;
 import android.os.Handler;
 import android.view.GestureDetector;
@@ -30,6 +31,7 @@ class ICBOnTouchListener implements View.OnTouchListener {
 
 	private final RelativeLayout keyboardGroup;
 	private final GestureDetector detect;
+	private final ActionBar actionBar;
 	private final Handler handler = new Handler();
 	private final Runnable hider;
 
@@ -44,14 +46,31 @@ class ICBOnTouchListener implements View.OnTouchListener {
 
 			keyboardGroup.startAnimation(consoleActivity.keyboard_fade_out);
 			keyboardGroup.setVisibility(View.GONE);
+			if (actionBar != null) {
+				actionBar.hide();
+			}
 		}
 	}
 
-	public ICBOnTouchListener (ConsoleActivity consoleActivity, RelativeLayout keyboardGroup, GestureDetector detect) {
+	public ICBOnTouchListener (ConsoleActivity consoleActivity, RelativeLayout keyboardGroup,
+							   ActionBar actionBar, GestureDetector detect) {
 		this.consoleActivity = consoleActivity;
 		this.keyboardGroup = keyboardGroup;
+		this.actionBar = actionBar;
 		this.detect = detect;
 		this.hider = new Hider();
+
+		if (actionBar != null) {
+			actionBar.addOnMenuVisibilityListener(new ActionBar.OnMenuVisibilityListener() {
+					public void onMenuVisibilityChanged(boolean isVisible) {
+						if (isVisible) {
+							handler.removeCallbacks(hider);
+						} else {
+							handler.postDelayed(hider, ConsoleActivity.KEYBOARD_DISPLAY_TIME);
+						}
+					}
+				});
+		}
 	}
 
 	public boolean onTouch(View v, MotionEvent event) {
@@ -130,6 +149,9 @@ class ICBOnTouchListener implements View.OnTouchListener {
 				&& Math.abs(event.getY() - lastY) < ConsoleActivity.MAX_CLICK_DISTANCE) {
 			keyboardGroup.startAnimation(consoleActivity.keyboard_fade_in);
 			keyboardGroup.setVisibility(View.VISIBLE);
+			if (actionBar != null) {
+				actionBar.show();
+			}
 
 			handler.postDelayed(this.hider, ConsoleActivity.KEYBOARD_DISPLAY_TIME);
 		}


### PR DESCRIPTION
Currently, if you disable the action bar on ICS+, you have no way to get to the menu. This change makes the action bar show up transiently when you touch the terminal, so that you can still access the menu, but have the increased terminal size that comes with hiding the action bar. The action bar and buttons won't be hidden while the menu is open.
